### PR TITLE
Skip archived cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+.env
+.idea

--- a/main.py
+++ b/main.py
@@ -230,6 +230,11 @@ def writeCollectionsAndCards(session, writerType, writer) -> None:
         # Now we'll loop over all cards
         for card in range(max):
             card_metadata = getSourcesFromCard(session, card + 1)[0]
+
+            # Skip archived cards
+            if 'archived' in card_metadata and card_metadata['archived'] is True:
+                continue
+
             createGUICard = f"CREATE (Card__{card_metadata['card_id']}:Card {{name: '{sanitize_names(card_metadata['card_name'])}', key: 'card{card_metadata['card_id']}'}})\n"
             matchCardAndCollection = f"MATCH (a_collection:Collection {{name: '{card_metadata['collection_slug']}'}}), (a_card:Card {{key: 'card{card_metadata['card_id']}'}})\n"
             createGUICardRelationshipToCollection = f"CREATE (a_card)-[:BELONGS_TO]->(a_collection)\n"


### PR DESCRIPTION
Hi, thanks for the application and the talk the other week!

I've been using it to trace lineage on a couple of dashboards, and I noticed it would populate the database with archived cards. Since archived cards really aren't considered "usages" anymore by most people, I'd suggest to simply filter them out and never write them into the database.

Let me know if you want me to put this change behind a cli flag or similar. What you see below is just the "raw" changes I made in order to make your code fit my needs.

It's also entirely OK to disregard my PR. I'll just keep using my fork, no hard feeling :-) 